### PR TITLE
Update the CircleCI docker image executors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:14.15.5-browsers
+      - image: cimg/node:14.21.2-browsers
   docker-python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
 
 references:
   workspace_root: &workspace_root '~'


### PR DESCRIPTION
# What:
 - Updated CircleCI executors to new and supported version.

# Why:
 - The ones prefixed with `circleci/` are no longer supported by CircleCI, which may cause issues in the future.