### PR TITLE
Upgrade Node runtime to 20.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:14.21.2-browsers
+      - image: cimg/node:20.18.2-browsers
   docker-python:
     docker:
       - image: cimg/python:3.7
@@ -159,6 +159,7 @@ workflows:
                 - staging
                 - main
       - build-deploy-staging:
+          context: "Serverless Framework"
           requires:
             - assume-role-staging
           filters:
@@ -181,6 +182,7 @@ workflows:
             branches:
               only: main
       - build-deploy-production:
+          context: "Serverless Framework"
           requires:
             - assume-role-production
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,12 +136,12 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies
-          # filters:
-          #   branches:
-          #     only:
-          #       - staging
-          #       - main
+      - install-dependencies:
+          filters:
+            branches:
+              only:
+                - staging
+                - main
       # - tests:
       #     requires:
       #       - install-dependencies
@@ -153,20 +153,20 @@ workflows:
           requires:
             - install-dependencies
           #   - e2e
-          # filters:
-          #   branches:
-          #     only: 
-          #       - staging
-          #       - main
+          filters:
+            branches:
+              only: 
+                - staging
+                - main
       - build-deploy-staging:
           context: "Serverless Framework"
           requires:
             - assume-role-staging
-          # filters:
-          #   branches:
-          #     only: 
-          #       - staging
-          #       - main
+          filters:
+            branches:
+              only: 
+                - staging
+                - main
       - permit-deploy-production:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,12 +136,12 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies:
-          filters:
-            branches:
-              only:
-                - staging
-                - main
+      - install-dependencies
+          # filters:
+          #   branches:
+          #     only:
+          #       - staging
+          #       - main
       # - tests:
       #     requires:
       #       - install-dependencies
@@ -153,20 +153,20 @@ workflows:
           requires:
             - install-dependencies
           #   - e2e
-          filters:
-            branches:
-              only: 
-                - staging
-                - main
+          # filters:
+          #   branches:
+          #     only: 
+          #       - staging
+          #       - main
       - build-deploy-staging:
           context: "Serverless Framework"
           requires:
             - assume-role-staging
-          filters:
-            branches:
-              only: 
-                - staging
-                - main
+          # filters:
+          #   branches:
+          #     only: 
+          #       - staging
+          #       - main
       - permit-deploy-production:
           type: approval
           requires:

--- a/serverless.yml
+++ b/serverless.yml
@@ -26,7 +26,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs20.x
   lambdaHashingVersion: 20201221
 
 # you can overwrite defaults here


### PR DESCRIPTION
This PR upgrades the lambda runtime to `Node 20.x` as `Node 12.x` is deprecated. There are also some fixes to the CircleCI config to get the pipeline working.

**Updates to CircleCI configuration:**

* Updated Docker image for `node-executor` to a newer version.
* Added `context: "Serverless Framework"` to `build-deploy-staging` and `build-deploy-production` workflows. 

**Updates to Serverless framework configuration:**

* Changed the `runtime` from `nodejs12.x` to `nodejs20.x`.